### PR TITLE
Resource group to default

### DIFF
--- a/test/cloud_function_test.go
+++ b/test/cloud_function_test.go
@@ -17,7 +17,7 @@ func TestAccIBMCloudFunction(t *testing.T) {
 		TerraformDir: "../examples/cloud-function",
 
 		Vars: map[string]interface{}{
-			"resource_group":                   "Default",
+			"resource_group":                   "default",
 			"action_name":                      "cf-action2",
 			"namespace_name":                   "cf-namespace",
 			"provision_namespace":              true,


### PR DESCRIPTION
Test cases are failing because resource group is Default. Changed to small default.